### PR TITLE
Update flatbuffers compiler version to 24.3.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers-build"
-version = "0.1.2+flatc-23.5.26"
+version = "0.1.2+flatc-24.3.25"
 dependencies = [
  "anyhow",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatbuffers-build"
-version = "0.1.2+flatc-23.5.26"
+version = "0.1.2+flatc-24.3.25"
 edition = "2021"
 license = "MIT"
 categories = ["encoding"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ of `flatbuffers`:
 # Cargo.toml
 # [...]
 [dependencies]
-flatbuffers = "=23.5.26"
+flatbuffers = "=24.3.25"
 
 [build-dependencies]
 flatbuffers-build = "=0.1.0"

--- a/build.rs
+++ b/build.rs
@@ -18,9 +18,9 @@ mod vendored {
 
     const SOURCE_URL: &str =
         "https://github.com/google/flatbuffers/archive/refs/tags/v{version}.tar.gz";
-    const SUPPORTED_FLATC_VERSION: &str = "23.5.26";
+    const SUPPORTED_FLATC_VERSION: &str = "24.3.25";
     const CHECKSUM_SHA256: &str =
-        "1cce06b17cddd896b6d73cc047e36a254fb8df4d7ea18a46acf16c4c0cd3f3f3";
+        "4157c5cacdb59737c5d627e47ac26b140e9ee28b1102f812b36068aab728c1ed";
     const EXTRACT_DIRECTORY_PREFIX: &str = "flatbuffers-{version}";
 
     pub fn vendor_flatc() -> anyhow::Result<()> {

--- a/flatbuffers-build-example/Cargo.lock
+++ b/flatbuffers-build-example/Cargo.lock
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers"
-version = "23.5.26"
+version = "24.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+checksum = "8add37afff2d4ffa83bc748a70b4b1370984f6980768554182424ef71447c35f"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers-build"
-version = "0.1.1+flatc-23.5.26"
+version = "0.1.2+flatc-24.3.25"
 dependencies = [
  "anyhow",
  "cmake",

--- a/flatbuffers-build-example/Cargo.toml
+++ b/flatbuffers-build-example/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/rdelfin/flatbuffers-build"
 
 [dependencies]
 anyhow = "1"
-flatbuffers = "=23.5.26"
+flatbuffers = "=24.3.25"
 
 [build-dependencies]
-flatbuffers-build = { version = "0.1.1", path = "..", features = ["vendored"] }
+flatbuffers-build = { version = "0.1.2", path = "..", features = ["vendored"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,10 @@
 //! # Cargo.toml
 //! # [...]
 //! [dependencies]
-//! flatbuffers = "=23.5.26"
+//! flatbuffers = "=24.3.25"
 //!
 //! [build-dependencies]
-//! flatbuffers-build = "=23.5.26"
+//! flatbuffers-build = "=24.3.25"
 //! # [...]
 //! ```
 //!
@@ -88,7 +88,7 @@ const FLATC_BUILD_PATH: Option<&str> = option_env!("FLATC_PATH");
 
 /// Version of `flatc` supported by this library. Make sure this matches exactly with the `flatc`
 /// binary you're using and the version of the `flatbuffers` rust library.
-pub const SUPPORTED_FLATC_VERSION: &str = "23.5.26";
+pub const SUPPORTED_FLATC_VERSION: &str = "24.3.25";
 
 /// Primary error type returned when you compile your flatbuffer specifications to Rust.
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
This updates the version of the flatbuffers compiler to newest release (24.3.25) after a version was published.