### PR TITLE
Support windows targets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,10 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "cmake",
  "flate2",
  "hex",
+ "junction",
  "reqwest",
  "ring",
  "tar",
@@ -463,6 +464,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "junction"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -786,6 +797,12 @@ checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ repository = "https://github.com/rdelfin/flatbuffers-build"
 [dependencies]
 thiserror = "1"
 
+[target.'cfg(windows)'.dependencies]
+junction = "1.2.0"
+
 [features]
 vendored = ["anyhow", "cmake", "flate2", "hex", "reqwest", "ring", "tar", "tempfile"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,10 @@ fn generate_symlink<P: AsRef<Path>, Q: AsRef<Path>>(symlink_path: P, output_path
     if symlink_path.as_ref().exists() {
         std::fs::remove_file(&symlink_path).map_err(Error::SymlinkCreationFailure)?;
     }
+    #[cfg(unix)]
     std::os::unix::fs::symlink(output_path, symlink_path).map_err(Error::SymlinkCreationFailure)?;
+    #[cfg(windows)]
+    junction::create(output_path, symlink_path).map_err(Error::SymlinkCreationFailure)?;
     Ok(())
 }
 


### PR DESCRIPTION
Tested on windows 10 and windows 11.

EDIT: It seems there is something else within the extraction that relies on windows symlinks directly which is an issue for non-admin users:

```
15:01:14  Caused by:
15:01:14    process didn't exit successfully: `C:/target\release\build\flatbuffers-build-a81ddc4b08ecd034\build-script-build` (exit code: 101)
15:01:14    --- stderr
15:01:14    thread 'main' panicked at C:\.cargo\git\checkouts\flatbuffers-build-8ef4ff77bea6d0f6\46e481f\build.rs:5:30:
15:01:14    failed to vendor flatc: failed to unpack `\\?\C:\tmp\.tmp6bPG6a\flatbuffers\flatbuffers-24.3.25\docs\source\CONTRIBUTING.md`
15:01:14  
15:01:15    Caused by:
15:01:15        A required privilege is not held by the client. (os error 1314) when symlinking ../../CONTRIBUTING.md to \\?\C:\tmp\.tmp6bPG6a\flatbuffers\flatbuffers-24.3.25\docs\source\CONTRIBUTING.md
```