### PR TITLE
refactor(symlink): removed unecessary symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ You can then have a very simple `build.rs` as follows:
 use flatbuffers_build::BuilderOptions;
 
 BuilderOptions::new_with_files(["schemas/weapon.fbs", "schemas/example.fbs"])
-    .set_symlink_directory("src/gen_flatbuffers")
     .compile()
     .expect("flatbuffer compilation failed");
 ```
@@ -55,12 +54,14 @@ Note here that `weapon.fbs` and `example.fbs` are based on the schemas provided 
 `flatbuffers` as an example. The namespace is `MyGame.Sample` and it contains multiple tables
 and structs, including a `Monster` table.
 
-This will just compile the flatbuffers and drop them in `${OUT_DIR}/flatbuffers` and will
-create a symlink under `src/gen_flatbuffers`. You can then use them in `lib.rs` like so:
+This will just compile the flatbuffers and drop them in `${OUT_DIR}/flatbuffers`.
+You can then use them in `lib.rs` like so:
 
 ```rust
 #[allow(warnings)]
-mod gen_flatbuffers;
+mod gen_flatbuffers {
+    include!(concat!(env!("OUT_DIR"), "/flatbuffers/mod.rs"));
+}
 
 use gen_flatbuffers::my_game::sample::Monster;
 
@@ -69,8 +70,6 @@ fn some_fn() {
 }
 ```
 
-Note that since this will generate a symlink under `src/gen_flatbuffers`, you need to add this
-file to your gitignore as this symlink will dynamically change at runtime.
 
 ## On file ordering
 

--- a/flatbuffers-build-example/Cargo.lock
+++ b/flatbuffers-build-example/Cargo.lock
@@ -175,12 +175,13 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers-build"
-version = "0.1.2+flatc-24.3.25"
+version = "0.2.1+flatc-24.3.25"
 dependencies = [
  "anyhow",
  "cmake",
  "flate2",
  "hex",
+ "junction",
  "reqwest",
  "ring",
  "tar",
@@ -476,6 +477,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "junction"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -801,6 +812,12 @@ checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"

--- a/flatbuffers-build-example/Cargo.toml
+++ b/flatbuffers-build-example/Cargo.toml
@@ -15,4 +15,4 @@ anyhow = "1"
 flatbuffers = "=24.3.25"
 
 [build-dependencies]
-flatbuffers-build = { version = "0.1.2", path = "..", features = ["vendored"] }
+flatbuffers-build = { version = "0.2.1", path = "..", features = ["vendored"] }

--- a/flatbuffers-build-example/build.rs
+++ b/flatbuffers-build-example/build.rs
@@ -2,7 +2,6 @@ use flatbuffers_build::BuilderOptions;
 
 fn main() {
     BuilderOptions::new_with_files(["schemas/weapon.fbs", "schemas/example.fbs"])
-        .set_symlink_directory("src/gen_flatbuffers")
         .compile()
         .expect("flatbuffer compilation failed")
 }

--- a/flatbuffers-build-example/src/main.rs
+++ b/flatbuffers-build-example/src/main.rs
@@ -1,6 +1,7 @@
 // Example crate
 
 #[allow(warnings)]
+#[rustfmt::skip]
 mod gen_flatbuffers {
     // for a cleaner code, you could do this in a separate module
     include!(concat!(env!("OUT_DIR"), "/flatbuffers/mod.rs"));

--- a/flatbuffers-build-example/src/main.rs
+++ b/flatbuffers-build-example/src/main.rs
@@ -1,9 +1,10 @@
 // Example crate
 
 #[allow(warnings)]
-#[rustfmt::skip]
-mod gen_flatbuffers;
-
+mod gen_flatbuffers {
+    // for a cleaner code, you could do this in a separate module
+    include!(concat!(env!("OUT_DIR"), "/flatbuffers/mod.rs"));
+}
 use gen_flatbuffers::my_game::sample::{Monster, MonsterArgs, Vec3};
 
 fn main() -> anyhow::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //! `flatbuffers` as an example. The namespace is `MyGame.Sample` and it contains multiple tables
 //! and structs, including a `Monster` table.
 //!
-//! This will just compile the flatbuffers and drop them in `${OUT_DIR}/flatbuffers` 
+//! This will just compile the flatbuffers and drop them in `${OUT_DIR}/flatbuffers`
 //! You can then use them in `lib.rs` like so:
 //!
 //! ```rust,ignore
@@ -277,7 +277,6 @@ fn compile(builder_options: BuilderOptions) -> Result {
     }
     Ok(())
 }
-
 
 fn confirm_flatc_version(compiler: &str) -> Result {
     // Output shows up in stdout

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@
 //! use flatbuffers_build::BuilderOptions;
 //!
 //! BuilderOptions::new_with_files(["schemas/weapon.fbs", "schemas/example.fbs"])
-//!     .set_symlink_directory("src/gen_flatbuffers")
 //!     .compile()
 //!     .expect("flatbuffer compilation failed");
 //! ```
@@ -50,12 +49,14 @@
 //! `flatbuffers` as an example. The namespace is `MyGame.Sample` and it contains multiple tables
 //! and structs, including a `Monster` table.
 //!
-//! This will just compile the flatbuffers and drop them in `${OUT_DIR}/flatbuffers` and will
-//! create a symlink under `src/gen_flatbuffers`. You can then use them in `lib.rs` like so:
+//! This will just compile the flatbuffers and drop them in `${OUT_DIR}/flatbuffers` 
+//! You can then use them in `lib.rs` like so:
 //!
 //! ```rust,ignore
 //! #[allow(warnings)]
-//! mod gen_flatbuffers;
+//! mod gen_flatbuffers {
+//!     include!(concat!(env!("OUT_DIR"), "/flatbuffers/mod.rs"));
+//! }
 //!
 //! use gen_flatbuffers::my_game::sample::Monster;
 //!
@@ -64,8 +65,6 @@
 //! }
 //! ```
 //!
-//! Note that since this will generate a symlink under `src/gen_flatbuffers`, you need to add this
-//! file to your gitignore as this symlink will dynamically change at runtime.
 //!
 //! ## On file ordering
 //!
@@ -121,11 +120,6 @@ pub enum Error {
         "output directory was not set. Either call .set_output_path() or set the `OUT_DIR` env var"
     )]
     OutputDirNotSet,
-    /// Returned when an issue arrises when creating the symlink. Typically this will be things
-    /// like permissions, a directory existing already at the file location, or other filesystem
-    /// errors.
-    #[error("failed to create symlink path requested: {0}")]
-    SymlinkCreationFailure(#[source] std::io::Error),
 }
 
 /// Alias for a Result that uses [`Error`] as the default error type.
@@ -157,7 +151,6 @@ pub struct BuilderOptions {
     files: Vec<PathBuf>,
     compiler: Option<String>,
     output_path: Option<PathBuf>,
-    symlink_path: Option<PathBuf>,
     supress_buildrs_directives: bool,
 }
 
@@ -184,7 +177,6 @@ impl BuilderOptions {
             files: files.into_iter().map(|f| f.as_ref().into()).collect(),
             compiler: None,
             output_path: None,
-            symlink_path: None,
             supress_buildrs_directives: false,
         }
     }
@@ -213,20 +205,6 @@ impl BuilderOptions {
     pub fn set_output_path<P: AsRef<Path>>(self, output_path: P) -> Self {
         BuilderOptions {
             output_path: Some(output_path.as_ref().into()),
-            ..self
-        }
-    }
-
-    /// Set a path to create a symlink that points to the output files. This is commonly used to
-    /// symlink to a folder under `src` so you can normally pull in the generated code as a module.
-    /// We recommend always calling this and setting it to `src/generated` or something similar.
-    ///
-    /// # Arguments
-    /// * `symlink_path` - Path to generate the symlink to.
-    #[must_use]
-    pub fn set_symlink_directory<P: AsRef<Path>>(self, symlink_path: P) -> Self {
-        BuilderOptions {
-            symlink_path: Some(symlink_path.as_ref().into()),
             ..self
         }
     }
@@ -292,13 +270,6 @@ fn compile(builder_options: BuilderOptions) -> Result {
     args.extend(files_str);
     run_flatc(&compiler, &args)?;
 
-    if let Some(symlink_path) = builder_options.symlink_path {
-        generate_symlink(&symlink_path, PathBuf::from(output_path))?;
-        if !builder_options.supress_buildrs_directives {
-            println!("cargo::rerun-if-changed={}", symlink_path.display());
-        }
-    }
-
     if !builder_options.supress_buildrs_directives {
         for file in builder_options.files {
             println!("cargo::rerun-if-changed={}", file.display());
@@ -307,16 +278,6 @@ fn compile(builder_options: BuilderOptions) -> Result {
     Ok(())
 }
 
-fn generate_symlink<P: AsRef<Path>, Q: AsRef<Path>>(symlink_path: P, output_path: Q) -> Result {
-    if symlink_path.as_ref().exists() {
-        std::fs::remove_file(&symlink_path).map_err(Error::SymlinkCreationFailure)?;
-    }
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(output_path, symlink_path).map_err(Error::SymlinkCreationFailure)?;
-    #[cfg(windows)]
-    junction::create(output_path, symlink_path).map_err(Error::SymlinkCreationFailure)?;
-    Ok(())
-}
 
 fn confirm_flatc_version(compiler: &str) -> Result {
     // Output shows up in stdout


### PR DESCRIPTION
`Fix`: #15 
Removed the _symlink_ generation feature from the library and updated the usage examples accordingly