### PR TITLE
Generate Object API by default

### DIFF
--- a/flatbuffers-build-example/Cargo.lock
+++ b/flatbuffers-build-example/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers-build"
-version = "0.2.1+flatc-25.2.10"
+version = "0.2.2+flatc-25.2.10"
 dependencies = [
  "anyhow",
  "cmake",

--- a/flatbuffers-build-example/build.rs
+++ b/flatbuffers-build-example/build.rs
@@ -2,6 +2,7 @@ use flatbuffers_build::BuilderOptions;
 
 fn main() {
     BuilderOptions::new_with_files(["schemas/weapon.fbs", "schemas/example.fbs"])
+        .gen_object_api()
         .compile()
         .expect("flatbuffer compilation failed")
 }

--- a/flatbuffers-build-example/src/main.rs
+++ b/flatbuffers-build-example/src/main.rs
@@ -6,9 +6,10 @@ mod gen_flatbuffers {
     // for a cleaner code, you could do this in a separate module
     include!(concat!(env!("OUT_DIR"), "/flatbuffers/mod.rs"));
 }
-use gen_flatbuffers::my_game::sample::{Monster, MonsterArgs, Vec3};
+use gen_flatbuffers::my_game::sample::{Monster, MonsterArgs, MonsterT, Vec3, WeaponT};
 
 fn main() -> anyhow::Result<()> {
+    // Use builder style:
     // Writing a monster object to encoded bytes
     let mut builder = flatbuffers::FlatBufferBuilder::with_capacity(1024);
     let m = Monster::create(
@@ -23,7 +24,27 @@ fn main() -> anyhow::Result<()> {
 
     // Reading the object back
     let monster = flatbuffers::root::<Monster>(encoded_data)?;
-    println!("Read back monster: {monster:?}");
+    println!("Read back monster (created builder style): {monster:?}");
+
+    // Use Object style:
+    let mut builder = flatbuffers::FlatBufferBuilder::with_capacity(1024);
+    let sword: WeaponT = WeaponT {
+        name: Some("sword".to_string()),
+        damage: 420,
+    };
+    let m: MonsterT = MonsterT {
+        name: Some("Le MonsterT".to_string()),
+        weapons: vec![sword].into(),
+        ..Default::default()
+    };
+
+    let monster_offset = m.pack(&mut builder);
+    builder.finish(monster_offset, None);
+    let encoded_data = builder.finished_data();
+
+    // Reading the object back
+    let monster = flatbuffers::root::<Monster>(encoded_data)?;
+    println!("Read back monster (create with object api): {monster:?}");
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@ pub struct BuilderOptions {
     compiler: Option<String>,
     output_path: Option<PathBuf>,
     supress_buildrs_directives: bool,
+    gen_object_api: bool,
 }
 
 impl BuilderOptions {
@@ -178,6 +179,7 @@ impl BuilderOptions {
             compiler: None,
             output_path: None,
             supress_buildrs_directives: false,
+            gen_object_api: false,
         }
     }
 
@@ -215,6 +217,17 @@ impl BuilderOptions {
     pub fn supress_buildrs_directives(self) -> Self {
         BuilderOptions {
             supress_buildrs_directives: true,
+            ..self
+        }
+    }
+
+    /// Generate an additional object-based API. This API is more convenient for object construction
+    /// and mutation than the base API, at the cost of efficiency (object allocation).
+    /// Recommended only to be used if other options are insufficient.
+    #[must_use]
+    pub fn gen_object_api(self) -> Self {
+        BuilderOptions {
+            gen_object_api: true,
             ..self
         }
     }
@@ -264,9 +277,13 @@ fn compile(builder_options: BuilderOptions) -> Result {
     let mut args = vec![
         OsString::from("--rust"),
         OsString::from("--rust-module-root-file"),
-        OsString::from("-o"),
-        output_path.clone(),
     ];
+
+    if builder_options.gen_object_api {
+        args.push(OsString::from("--gen-object-api"));
+    }
+
+    args.extend(vec![OsString::from("-o"), output_path.clone()]);
     args.extend(files_str);
     run_flatc(&compiler, &args)?;
 


### PR DESCRIPTION
Expanended example with the new Object API.
This is fully backwards compatible and just added new Object types for simpler pack and unpack messages with Flatbuffers.

Fixes #24 