### PR TITLE
Update flatbuffers to latest 25.12.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers-build"
-version = "0.2.3+flatc-25.2.10"
+version = "0.2.4+flatc-25.9.23"
 dependencies = [
  "anyhow",
  "cmake",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers-build"
-version = "0.2.4+flatc-25.9.23"
+version = "0.2.4+flatc-25.12.19"
 dependencies = [
  "anyhow",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatbuffers-build"
-version = "0.2.4+flatc-25.9.23"
+version = "0.2.4+flatc-25.12.19"
 edition = "2021"
 license = "MIT"
 categories = ["encoding"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatbuffers-build"
-version = "0.2.3+flatc-25.2.10"
+version = "0.2.4+flatc-25.9.23"
 edition = "2021"
 license = "MIT"
 categories = ["encoding"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ of `flatbuffers`:
 # Cargo.toml
 # [...]
 [dependencies]
-flatbuffers = "=25.9.23"
+flatbuffers = "=25.12.19"
 
 [build-dependencies]
 flatbuffers-build = "=0.1.0"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ of `flatbuffers`:
 # Cargo.toml
 # [...]
 [dependencies]
-flatbuffers = "=25.2.10"
+flatbuffers = "=25.9.23"
 
 [build-dependencies]
 flatbuffers-build = "=0.1.0"

--- a/build.rs
+++ b/build.rs
@@ -18,9 +18,9 @@ mod vendored {
 
     const SOURCE_URL: &str =
         "https://github.com/google/flatbuffers/archive/refs/tags/v{version}.tar.gz";
-    const SUPPORTED_FLATC_VERSION: &str = "25.9.23";
+    const SUPPORTED_FLATC_VERSION: &str = "25.12.19";
     const CHECKSUM_SHA256: &str =
-        "9102253214dea6ae10c2ac966ea1ed2155d22202390b532d1dea64935c518ada";
+        "f81c3162b1046fe8b84b9a0dbdd383e24fdbcf88583b9cb6028f90d04d90696a";
     const EXTRACT_DIRECTORY_PREFIX: &str = "flatbuffers-{version}";
 
     pub fn vendor_flatc() -> anyhow::Result<()> {

--- a/build.rs
+++ b/build.rs
@@ -18,9 +18,9 @@ mod vendored {
 
     const SOURCE_URL: &str =
         "https://github.com/google/flatbuffers/archive/refs/tags/v{version}.tar.gz";
-    const SUPPORTED_FLATC_VERSION: &str = "25.2.10";
+    const SUPPORTED_FLATC_VERSION: &str = "25.9.23";
     const CHECKSUM_SHA256: &str =
-        "b9c2df49707c57a48fc0923d52b8c73beb72d675f9d44b2211e4569be40a7421";
+        "9102253214dea6ae10c2ac966ea1ed2155d22202390b532d1dea64935c518ada";
     const EXTRACT_DIRECTORY_PREFIX: &str = "flatbuffers-{version}";
 
     pub fn vendor_flatc() -> anyhow::Result<()> {

--- a/flatbuffers-build-example/Cargo.lock
+++ b/flatbuffers-build-example/Cargo.lock
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers"
-version = "25.2.10"
+version = "25.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
+checksum = "09b6620799e7340ebd9968d2e0708eb82cf1971e9a16821e2091b6d6e475eed5"
 dependencies = [
  "bitflags 2.9.1",
  "rustc_version",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers-build"
-version = "0.2.2+flatc-25.2.10"
+version = "0.2.4+flatc-25.9.23"
 dependencies = [
  "anyhow",
  "cmake",

--- a/flatbuffers-build-example/Cargo.lock
+++ b/flatbuffers-build-example/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers"
-version = "25.9.23"
+version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09b6620799e7340ebd9968d2e0708eb82cf1971e9a16821e2091b6d6e475eed5"
 dependencies = [
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers-build"
-version = "0.2.4+flatc-25.9.23"
+version = "0.2.4+flatc-25.12.19"
 dependencies = [
  "anyhow",
  "cmake",

--- a/flatbuffers-build-example/Cargo.toml
+++ b/flatbuffers-build-example/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/rdelfin/flatbuffers-build"
 
 [dependencies]
 anyhow = "1"
-flatbuffers = "=25.9.23"
+flatbuffers = "=25.12.19"
 
 [build-dependencies]
 flatbuffers-build = { version = "0.2.1", path = "..", features = ["vendored"] }

--- a/flatbuffers-build-example/Cargo.toml
+++ b/flatbuffers-build-example/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/rdelfin/flatbuffers-build"
 
 [dependencies]
 anyhow = "1"
-flatbuffers = "=25.2.10"
+flatbuffers = "=25.9.23"
 
 [build-dependencies]
 flatbuffers-build = { version = "0.2.1", path = "..", features = ["vendored"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,10 @@
 //! # Cargo.toml
 //! # [...]
 //! [dependencies]
-//! flatbuffers = "=25.2.10"
+//! flatbuffers = "=25.9.23"
 //!
 //! [build-dependencies]
-//! flatbuffers-build = "=25.2.10"
+//! flatbuffers-build = "=25.9.23"
 //! # [...]
 //! ```
 //!
@@ -87,7 +87,7 @@ const FLATC_BUILD_PATH: Option<&str> = option_env!("FLATC_PATH");
 
 /// Version of `flatc` supported by this library. Make sure this matches exactly with the `flatc`
 /// binary you're using and the version of the `flatbuffers` rust library.
-pub const SUPPORTED_FLATC_VERSION: &str = "25.2.10";
+pub const SUPPORTED_FLATC_VERSION: &str = "25.9.23";
 
 /// Primary error type returned when you compile your flatbuffer specifications to Rust.
 #[derive(thiserror::Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,10 @@
 //! # Cargo.toml
 //! # [...]
 //! [dependencies]
-//! flatbuffers = "=25.9.23"
+//! flatbuffers = "=25.12.19"
 //!
 //! [build-dependencies]
-//! flatbuffers-build = "=25.9.23"
+//! flatbuffers-build = "=25.12.19"
 //! # [...]
 //! ```
 //!
@@ -87,7 +87,7 @@ const FLATC_BUILD_PATH: Option<&str> = option_env!("FLATC_PATH");
 
 /// Version of `flatc` supported by this library. Make sure this matches exactly with the `flatc`
 /// binary you're using and the version of the `flatbuffers` rust library.
-pub const SUPPORTED_FLATC_VERSION: &str = "25.9.23";
+pub const SUPPORTED_FLATC_VERSION: &str = "25.12.19";
 
 /// Primary error type returned when you compile your flatbuffer specifications to Rust.
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
Fixes #29 

My build failed today because this crate is still not updated.

```
Error: Custom { kind: Other, error: UnsupportedFlatcVersion("25.9.23") }
```

I hope i caught all relevant parts for the update.